### PR TITLE
Adding pdfunite to Image

### DIFF
--- a/.devcontainer/image/Dockerfile
+++ b/.devcontainer/image/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && \
     python3 \
     python3-pygments \
     # Required to embed git metadata into PDF from within Docker container:
-    git
+    git \
     # Required to use pdfunite for merging PDF files. Ghostscript is causing
     # trouble with Mozilla Firefox's PDF Reader.
     poppler-utils

--- a/.devcontainer/image/Dockerfile
+++ b/.devcontainer/image/Dockerfile
@@ -81,6 +81,9 @@ RUN apt-get update && \
     python3-pygments \
     # Required to embed git metadata into PDF from within Docker container:
     git
+    # Required to use pdfunite for merging PDF files. Ghostscript is causing
+    # trouble with Mozilla Firefox's PDF Reader.
+    poppler-utils
 
 # The `minted` LaTeX package provides syntax highlighting using the Python `pygmentize`
 # package. That package also installs a callable script, which `minted` uses, see


### PR DESCRIPTION
Adding pdfunite to the image to use this tool instead of Ghostscript to merge PDF-files. Because GS causes problems for Mozilla Firefox to display the PDFs.